### PR TITLE
Add write call before end call in unzip middleware

### DIFF
--- a/lib/server/proxy/lib/utils.js
+++ b/lib/server/proxy/lib/utils.js
@@ -173,13 +173,16 @@ function unzipRequestMiddleware(req, res, next) {
                 if (res._headers["x-zipped"]) {
                     zlib.unzip(buffer, function(err, unzippedBuffer) {
                         if (!err) {
-                            _end.call(res, unzippedBuffer, encoding);
+                            _write.call(res, unzippedBuffer, encoding);
+                            _end.call(res, null, encoding);
                         } else {
-                            _end.call(res, buffer, encoding);
+                            _write.call(res, buffer, encoding);
+                            _end.call(res, null, encoding);
                         }
                     });
                 } else {
-                    _end.call(res, buffer, encoding);
+                    _write.call(res, buffer, encoding);
+                    _end.call(res, null, encoding);
                 }
             } else {
               _end.call(res, data, encoding);


### PR DESCRIPTION
Single response write is needed before response end can be called.