### PR TITLE
Fix WP7 transport to be polling

### DIFF
--- a/lib/messages.js
+++ b/lib/messages.js
@@ -61,6 +61,7 @@ var messages = {
         var template = "window.___browserSync___ = {};";
         template    += "___browserSync___.io = window.io; try{delete window.io;}catch(err){window.io=undefined;};";
         template    += "___browserSync___.socketConfig = {}; ___browserSync___.socketConfig.path = '%path';";
+        template    += "if ('WebSocket' in window === false || navigator.userAgent.match(/Windows Phone OS 7\.5/)) { ___browserSync___.socketConfig.transports = [\"polling\"]; }";
         template    += "___browserSync___.socket = ___browserSync___.io(%url, ___browserSync___.socketConfig);";
 
         template = template


### PR DESCRIPTION
Force transport to be polling if user agent WP7 or WebSocket.